### PR TITLE
Bah 1636

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -73,13 +73,8 @@
         </dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito</artifactId>
+			<artifactId>powermock-api-mockito2</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
 		</dependency>
         <!-- End OpenMRS core -->
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -121,12 +121,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>${mockitoVersion}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>reporting-omod</artifactId>
 			<version>${reportingOmodVersion}</version>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -16,6 +16,9 @@
 	<properties>
 		<log4jVersion>2.17.1</log4jVersion>
 		<javaxServletVersion>4.0.1</javaxServletVersion>
+		<providerManagementVersion>2.13.0</providerManagementVersion>
+		<legacyUIVersion>1.8.0</legacyUIVersion>
+		<reportingOmodVersion>1.21.0</reportingOmodVersion>
 	</properties>
 
 	<dependencies>
@@ -108,13 +111,13 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>reporting-api</artifactId>
-			<version>0.10.4</version>
+			<version>${reportingOmodVersion}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>reporting-api-2.0</artifactId>
-			<version>0.10.4</version>
+			<version>${reportingOmodVersion}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -126,7 +129,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>reporting-omod</artifactId>
-			<version>0.10.4</version>
+			<version>${reportingOmodVersion}</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -158,13 +161,13 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>legacyui-omod</artifactId>
-			<version>1.3.2</version>
+			<version>${legacyUIVersion}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>providermanagement-api</artifactId>
-			<version>2.5.0</version>
+			<version>${providerManagementVersion}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -83,7 +83,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito</artifactId>
+			<artifactId>powermock-api-mockito2</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -114,6 +114,12 @@
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>reporting-api-2.0</artifactId>
 			<version>0.10.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>${mockitoVersion}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -15,6 +15,7 @@
 
 	<properties>
 		<log4jVersion>2.17.1</log4jVersion>
+		<javaxServletVersion>4.0.1</javaxServletVersion>
 	</properties>
 
 	<dependencies>
@@ -184,6 +185,13 @@
 			<artifactId>org.json</artifactId>
 			<version>20150729</version>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>${javaxServletVersion}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Log4j-->

--- a/omod/src/main/java/org/bahmni/module/bahmniOfflineSync/job/InitialSyncArtifactsPublisher.java
+++ b/omod/src/main/java/org/bahmni/module/bahmniOfflineSync/job/InitialSyncArtifactsPublisher.java
@@ -136,7 +136,7 @@ public class InitialSyncArtifactsPublisher extends AbstractTask {
     }
 
     private String getSql(Integer lastEventId, String filter) {
-        String template = "SELECT object, uuid FROM event_log WHERE filter = '%s' and id <= %d and category = 'patient' GROUP BY object";
+        String template = "SELECT object, uuid FROM event_log WHERE filter = '%s' and id <= %d and category = 'patient' GROUP BY object order by id";
         return String.format(template, filter, lastEventId);
     }
 

--- a/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/job/InitialSyncArtifactsPublisherIT.java
+++ b/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/job/InitialSyncArtifactsPublisherIT.java
@@ -10,9 +10,9 @@ import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 
-import static org.h2.engine.Constants.UTF8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -24,7 +24,7 @@ public class InitialSyncArtifactsPublisherIT extends BaseModuleWebContextSensiti
     @BeforeClass
     public static void createSchema() throws Exception {
         RunScript.execute("jdbc:h2:mem:openmrs;DB_CLOSE_DELAY=-1",
-                "sa", "", "classpath:schema.sql", UTF8, false);
+                "sa", "", "classpath:schema.sql", StandardCharsets.UTF_8, false);
     }
 
     @Before

--- a/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/job/InitialSyncArtifactsPublisherIT.java
+++ b/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/job/InitialSyncArtifactsPublisherIT.java
@@ -57,15 +57,15 @@ public class InitialSyncArtifactsPublisherIT extends BaseModuleWebContextSensiti
         JSONObject ganList_1 = unzip(ganFile_1);
         JSONArray ganPatients_1 = (JSONArray) ganList_1.get("patients");
         assertEquals(2, (ganPatients_1).length());
-        assertEquals("ac46eca0-51d5-11e3-8f96-0800200c9a66", ganList_1.get("lastReadEventUuid"));
-        assertEquals("ca17fcc5-ec96-487f-b9ea-42973c8973e3", ((JSONObject) ganPatients_1.get(0)).getString("uuid"));
-        assertEquals("61b38324-e2fd-4feb-95b7-9e9a2a4400df", ((JSONObject) ganPatients_1.get(1)).getString("uuid"));
+        assertEquals("ac46eca0-51d5-11e3-8f96-0800200c9a90", ganList_1.get("lastReadEventUuid"));
+        assertEquals("61b38324-e2fd-4feb-95b7-9e9a2a4400df", ((JSONObject) ganPatients_1.get(0)).getString("uuid"));
+        assertEquals("8d703ff2-c3e2-4070-9737-73e713d5a50d", ((JSONObject) ganPatients_1.get(1)).getString("uuid"));
 
         JSONObject ganList_2 = unzip(ganFile_2);
         JSONArray gan_2Patients = (JSONArray) ganList_2.get("patients");
         assertEquals(1, (gan_2Patients).length());
         assertEquals("ac46eca0-51d5-11e3-8f96-0800200c4a71", ganList_2.get("lastReadEventUuid"));
-        assertEquals("8d703ff2-c3e2-4070-9737-73e713d5a50d", ((JSONObject) gan_2Patients.get(0)).getString("uuid"));
+        assertEquals("ca17fcc5-ec96-487f-b9ea-42973c8973e3", ((JSONObject) gan_2Patients.get(0)).getString("uuid"));
 
 
         JSONObject semList = unzip(semFile);

--- a/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/web/v1/controller/InitialSyncArtifactControllerTest.java
+++ b/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/web/v1/controller/InitialSyncArtifactControllerTest.java
@@ -6,7 +6,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;

--- a/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/web/v1/controller/InitialSyncArtifactControllerTest.java
+++ b/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/web/v1/controller/InitialSyncArtifactControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Ignore;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -13,6 +14,7 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.core.io.FileSystemResource;
@@ -33,6 +35,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 @PrepareForTest({Context.class, IOUtils.class})
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
 public class InitialSyncArtifactControllerTest {
     @Mock
     AdministrationService administrationService;
@@ -121,6 +124,7 @@ public class InitialSyncArtifactControllerTest {
         controller.getPatientsByFilter(httpServletResponse, "ABCD.json.gz");
     }
 
+    @Ignore
     @Test
     public void shouldThrowAPIExceptionWhenFileIsPresentButUnableToParseTheContent() throws Exception {
         PowerMockito.mockStatic(IOUtils.class);

--- a/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/web/v1/controller/InitialSyncArtifactControllerTest.java
+++ b/omod/src/test/java/org/bahmni/module/bahmniOfflineSync/web/v1/controller/InitialSyncArtifactControllerTest.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -124,13 +125,12 @@ public class InitialSyncArtifactControllerTest {
         controller.getPatientsByFilter(httpServletResponse, "ABCD.json.gz");
     }
 
-    @Ignore
     @Test
     public void shouldThrowAPIExceptionWhenFileIsPresentButUnableToParseTheContent() throws Exception {
         PowerMockito.mockStatic(IOUtils.class);
         when(administrationService.getGlobalProperty(InitialSyncArtifactController.GP_BAHMNICONNECT_INIT_SYNC_PATH, InitialSyncArtifactController.DEFAULT_INIT_SYNC_PATH)).thenReturn(".");
         when(resourceLoader.getResource("file:./patient/ABC.json.gz")).thenReturn(new FileSystemResource(resultFile));
-        when(IOUtils.copy(any(InputStream.class), any(OutputStream.class))).thenThrow(new IOException());
+        when(IOUtils.copy(any(InputStream.class), (OutputStream) eq(null))).thenThrow(new IOException());
 
         InitialSyncArtifactController controller = new InitialSyncArtifactController();
         controller.setResourceLoader(resourceLoader);

--- a/omod/src/test/resources/TestingApplicationContext.xml
+++ b/omod/src/test/resources/TestingApplicationContext.xml
@@ -23,6 +23,11 @@
         <property name="mappingJarLocations">
             <ref bean="mappingJarResources" />
         </property>
+        <property name="packagesToScan">
+            <list>
+                <value>org.openmrs</value>
+            </list>
+        </property>
         <!--  default properties must be set in the hibernate.default.properties -->
     </bean>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,17 @@
     </modules>
 
     <properties>
-        <openMRSVersion>2.1.6</openMRSVersion>
+        <openMRSVersion>2.4.2</openMRSVersion>
         <atomfeed.version>1.10.1</atomfeed.version>
         <openmrsAtomfeedVersion>2.6.1</openmrsAtomfeedVersion>
         <serializationXstreamModuleVersion>0.2.12</serializationXstreamModuleVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <addressHierarchyVersion>2.9</addressHierarchyVersion>
-        <springVersion>4.1.4.RELEASE</springVersion>
-        <openMRSWebServicesVersion>2.17</openMRSWebServicesVersion>
-        <junitVersion>4.12</junitVersion>
-        <powerMockVersion>1.6.5</powerMockVersion>
+        <springVersion>5.2.9.RELEASE</springVersion>
+        <openMRSWebServicesVersion>2.29.0</openMRSWebServicesVersion>
+        <junitVersion>4.13</junitVersion>
+        <powerMockVersion>2.0.7</powerMockVersion>
+        <mockitoVersion>3.5.11</mockitoVersion>
         <emrapi-omod.version>1.22.1</emrapi-omod.version>
         <bahmni.ie.apps>1.2.0-SNAPSHOT</bahmni.ie.apps>
         <metadatamapping.version>1.3.2</metadatamapping.version>
@@ -62,7 +63,7 @@
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
+                <artifactId>powermock-api-mockito2</artifactId>
                 <version>${powerMockVersion}</version>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
                 <version>${openMRSVersion}</version>
                 <type>jar</type>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -98,6 +104,12 @@
                 <version>${openMRSVersion}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.openmrs.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,8 @@
         <junitVersion>4.13</junitVersion>
         <powerMockVersion>2.0.7</powerMockVersion>
         <mockitoVersion>3.5.11</mockitoVersion>
-        <emrapi-omod.version>1.22.1</emrapi-omod.version>
+        <emrapi-omod.version>1.32.0</emrapi-omod.version>
+        <idgen.version>4.6.0</idgen.version>
         <bahmni.ie.apps>1.2.0-SNAPSHOT</bahmni.ie.apps>
         <metadatamapping.version>1.3.2</metadatamapping.version>
     </properties>
@@ -187,7 +188,7 @@
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>idgen-api</artifactId>
-                <version>4.3</version>
+                <version>${idgen.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,7 @@
         <atomfeed.version>1.10.1</atomfeed.version>
         <openmrsAtomfeedVersion>2.6.1</openmrsAtomfeedVersion>
         <serializationXstreamModuleVersion>0.2.12</serializationXstreamModuleVersion>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <addressHierarchyVersion>2.9</addressHierarchyVersion>
-        <springVersion>5.2.9.RELEASE</springVersion>
         <openMRSWebServicesVersion>2.29.0</openMRSWebServicesVersion>
         <junitVersion>4.13</junitVersion>
         <powerMockVersion>2.0.7</powerMockVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <openMRSWebServicesVersion>2.29.0</openMRSWebServicesVersion>
         <junitVersion>4.13</junitVersion>
         <powerMockVersion>2.0.7</powerMockVersion>
-        <mockitoVersion>3.5.11</mockitoVersion>
         <emrapi-omod.version>1.32.0</emrapi-omod.version>
         <idgen.version>4.6.0</idgen.version>
         <bahmni.ie.apps>1.2.0-SNAPSHOT</bahmni.ie.apps>


### PR DESCRIPTION
This PR is about upgrading below versions

- openmrs-core to 2.4.2
- web-services to 2.29.0
- javax-servlet to 4.0.1 (kept scope as provided to resolve compile issues)
- reporting-omod to 1.21.0
- legacyui to 1.8.0
- provider-management to 2.13.0

Resolved failing test cases
Removed unused dependencies and imports