### PR TITLE
BAH-1890 Upgrade OMRS version from 2.4.2 to 2.5.0 in Bahmni Offline Sync Module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </modules>
 
     <properties>
-        <openMRSVersion>2.4.2</openMRSVersion>
+        <openMRSVersion>2.5.0</openMRSVersion>
         <atomfeed.version>1.10.1</atomfeed.version>
         <openmrsAtomfeedVersion>2.6.1</openmrsAtomfeedVersion>
         <serializationXstreamModuleVersion>0.2.12</serializationXstreamModuleVersion>


### PR DESCRIPTION
### Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1890 
Upgraded openMRSVersion to 2.5.0

### Solution
Add missing dependencies that have been generated due to version upgrade.

## The following changes have been made:

- udpated
openMRS v2.4.2 -> 2.5.0


### Testing
The screenshots for successful compilation have been added on the ticket.